### PR TITLE
Fix: Identity is mined but never assigned

### DIFF
--- a/bin/kadence.js
+++ b/bin/kadence.js
@@ -381,6 +381,7 @@ async function init() {
   node = new kadence.KademliaNode({
     logger,
     transport,
+    identity: Buffer.from(identity, 'hex'),
     contact,
     storage: levelup(encoding(leveldown(config.EmbeddedDatabaseDirectory)))
   });


### PR DESCRIPTION
In kadence.js identity was mined but never used in node initialization. Added identity to node instance.